### PR TITLE
Add core types and update docs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,23 @@
+name: Security Audit
+
+on:
+  schedule:
+    - cron: '0 5 * * 1'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run cargo audit
+        uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Cargo fmt
+        run: cargo fmt --all --check
+
+      - name: Cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Cargo test
+        run: cargo test --workspace
+
+      - name: Cargo doc
+        run: cargo doc --no-deps --workspace

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,63 @@
+name: Publish Rust Docs
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ '*' ]        # also publish on tag push
+  workflow_dispatch:     # allow manual trigger
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write        # required for OIDC deploy authentication
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rust-docs
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Build documentation
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: |
+          cargo doc --workspace --all-features --no-deps
+          echo '<meta http-equiv="refresh" content="0; url=corrmatch/index.html">' > target/doc/index.html
+
+      - name: Assemble Pages artifact
+        run: |
+          mkdir -p public
+          rsync -a target/doc/ public/
+
+      - name: Upload artifact for Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build-docs
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Build and publish release assets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Format check
+        run: cargo fmt --all --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: Tests (release)
+        run: cargo test --workspace --all-targets --all-features --release
+
+      - name: Package crates
+        run: |
+          cargo package -p genicp --locked
+          cargo package -p genapi-xml --locked
+
+      - name: Build release binaries
+        run: cargo build --release --locked --bin genicam-rs
+
+      - name: Collect artifacts
+        run: |
+          mkdir -p dist
+          BIN_NAME="genicam-rs-${{ github.ref_name }}"
+          cp target/release/genicam-rs "dist/${BIN_NAME}"
+          tar -czf "dist/${BIN_NAME}-x86_64-unknown-linux-gnu.tar.gz" -C dist "${BIN_NAME}"
+          rm "dist/${BIN_NAME}"
+          cp target/package/*.crate dist/
+          sha256sum dist/* > dist/SHA256SUMS.txt
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          files: |
+            dist/*.tar.gz
+            dist/*.crate
+            dist/SHA256SUMS.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # CHANGELOG
 
 ## Unreleased
-- Initial scaffolding.
+- Add core error types and result alias for fallible APIs.
+- Add `ImageView`, `ImagePyramid`, `Template`, and `TemplatePlan` foundations.
+- Add unit tests for image views, pyramid downsampling, and template stats.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,28 @@ reproducible matching with a minimal dependency footprint.
 - `simd`: SIMD-accelerated kernels via `wide` (off by default).
 - `image-io`: enable `image` crate helpers for examples (off by default).
 
+## Current building blocks
+```rust
+use corrmatch::{CorrMatchResult, ImagePyramid, ImageView, Template, TemplatePlan};
+
+fn prepare_plan(
+    image: &[u8],
+    width: usize,
+    height: usize,
+    tpl: Vec<u8>,
+    tpl_width: usize,
+    tpl_height: usize,
+) -> CorrMatchResult<TemplatePlan> {
+    let view = ImageView::from_slice(image, width, height)?;
+    let _pyramid = ImagePyramid::build_u8(view, 4)?;
+    let template = Template::new(tpl, tpl_width, tpl_height)?;
+    TemplatePlan::from_view(template.view())
+}
+```
+
 ## Planned API sketch
 ```rust
-use corrmatch::{CorrMatchError, Result};
+use corrmatch::CorrMatchResult;
 
 // Pseudo-code for the planned API shape.
 // let plan = corrmatch::TemplatePlan::new(template, config);
@@ -20,4 +39,4 @@ use corrmatch::{CorrMatchError, Result};
 ```
 
 ## Status
-Scaffolding; algorithms not implemented yet.
+Core data types are implemented; matching algorithms are not implemented yet.

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -1,3 +1,168 @@
-//! Image representations and pyramid utilities.
+//! Image views and pyramid utilities.
+//!
+//! `ImageView` is a borrowed 2D view into a 1D buffer with an explicit stride.
+//! The stride counts elements between the starts of consecutive rows, so a
+//! stride larger than the width represents padded rows. ROI slices are zero-copy
+//! views into the same backing slice and retain the original stride.
 
-pub(crate) mod pyramid;
+use crate::util::{CorrMatchError, CorrMatchResult};
+
+pub mod pyramid;
+
+/// Borrowed 2D image view with an explicit stride.
+#[derive(Copy, Clone)]
+pub struct ImageView<'a, T> {
+    data: &'a [T],
+    width: usize,
+    height: usize,
+    stride: usize,
+}
+
+impl<'a, T> ImageView<'a, T> {
+    /// Creates a contiguous view with `stride == width`.
+    pub fn from_slice(data: &'a [T], width: usize, height: usize) -> CorrMatchResult<Self> {
+        Self::new(data, width, height, width)
+    }
+
+    /// Creates a view with an explicit stride.
+    pub fn new(data: &'a [T], width: usize, height: usize, stride: usize) -> CorrMatchResult<Self> {
+        let needed = required_len(width, height, stride)?;
+        if data.len() < needed {
+            return Err(CorrMatchError::BufferTooSmall {
+                needed,
+                got: data.len(),
+            });
+        }
+        Ok(Self {
+            data,
+            width,
+            height,
+            stride,
+        })
+    }
+
+    /// Returns the image width in pixels.
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    /// Returns the image height in pixels.
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    /// Returns the stride in elements between row starts.
+    pub fn stride(&self) -> usize {
+        self.stride
+    }
+
+    /// Returns the backing slice including any row padding.
+    pub fn as_slice(&self) -> &'a [T] {
+        self.data
+    }
+
+    /// Returns the element at `(x, y)` if it is within bounds.
+    pub fn get(&self, x: usize, y: usize) -> Option<&'a T> {
+        if x >= self.width || y >= self.height {
+            return None;
+        }
+        let idx = y.checked_mul(self.stride)?.checked_add(x)?;
+        self.data.get(idx)
+    }
+
+    /// Returns a contiguous slice for row `y` with length `width`.
+    pub fn row(&self, y: usize) -> Option<&'a [T]> {
+        if y >= self.height {
+            return None;
+        }
+        let start = y.checked_mul(self.stride)?;
+        let end = start.checked_add(self.width)?;
+        self.data.get(start..end)
+    }
+
+    /// Returns a zero-copy ROI view into the same backing buffer.
+    pub fn roi(
+        &self,
+        x: usize,
+        y: usize,
+        width: usize,
+        height: usize,
+    ) -> CorrMatchResult<ImageView<'a, T>> {
+        if width == 0 || height == 0 {
+            return Err(CorrMatchError::InvalidDimensions { width, height });
+        }
+
+        let img_width = self.width;
+        let img_height = self.height;
+        if x >= img_width || y >= img_height {
+            return Err(CorrMatchError::RoiOutOfBounds {
+                x,
+                y,
+                width,
+                height,
+                img_width,
+                img_height,
+            });
+        }
+
+        let end_x = x.checked_add(width).ok_or(CorrMatchError::RoiOutOfBounds {
+            x,
+            y,
+            width,
+            height,
+            img_width,
+            img_height,
+        })?;
+        let end_y = y
+            .checked_add(height)
+            .ok_or(CorrMatchError::RoiOutOfBounds {
+                x,
+                y,
+                width,
+                height,
+                img_width,
+                img_height,
+            })?;
+        if end_x > img_width || end_y > img_height {
+            return Err(CorrMatchError::RoiOutOfBounds {
+                x,
+                y,
+                width,
+                height,
+                img_width,
+                img_height,
+            });
+        }
+
+        let start = y
+            .checked_mul(self.stride)
+            .and_then(|v| v.checked_add(x))
+            .ok_or(CorrMatchError::InvalidDimensions {
+                width: img_width,
+                height: img_height,
+            })?;
+        let data = self
+            .data
+            .get(start..)
+            .ok_or(CorrMatchError::BufferTooSmall {
+                needed: start.saturating_add(1),
+                got: self.data.len(),
+            })?;
+
+        ImageView::new(data, width, height, self.stride)
+    }
+}
+
+fn required_len(width: usize, height: usize, stride: usize) -> CorrMatchResult<usize> {
+    if width == 0 || height == 0 {
+        return Err(CorrMatchError::InvalidDimensions { width, height });
+    }
+    if stride < width {
+        return Err(CorrMatchError::InvalidStride { width, stride });
+    }
+    let needed = (height - 1)
+        .checked_mul(stride)
+        .and_then(|v| v.checked_add(width))
+        .ok_or(CorrMatchError::InvalidDimensions { width, height })?;
+    Ok(needed)
+}

--- a/src/image/pyramid.rs
+++ b/src/image/pyramid.rs
@@ -1,1 +1,158 @@
-//! Image pyramid construction and sampling helpers.
+//! Image pyramid construction for grayscale `u8` images.
+//!
+//! Downsampling uses a 2x2 box filter with integer rounding:
+//! `dst = ((a + b + c + d) + 2) / 4`. This is a deterministic baseline
+//! suitable for early scaffolding without introducing blur kernels yet.
+
+use crate::image::ImageView;
+use crate::util::{CorrMatchError, CorrMatchResult};
+
+/// Owned contiguous grayscale image buffer.
+pub struct OwnedImage {
+    data: Vec<u8>,
+    width: usize,
+    height: usize,
+    stride: usize,
+}
+
+impl OwnedImage {
+    pub(crate) fn from_vec(data: Vec<u8>, width: usize, height: usize) -> CorrMatchResult<Self> {
+        if width == 0 || height == 0 {
+            return Err(CorrMatchError::InvalidDimensions { width, height });
+        }
+        let needed = width
+            .checked_mul(height)
+            .ok_or(CorrMatchError::InvalidDimensions { width, height })?;
+        if data.len() < needed {
+            return Err(CorrMatchError::BufferTooSmall {
+                needed,
+                got: data.len(),
+            });
+        }
+        if data.len() > needed {
+            return Err(CorrMatchError::InvalidDimensions { width, height });
+        }
+        Ok(Self {
+            data,
+            width,
+            height,
+            stride: width,
+        })
+    }
+
+    pub(crate) fn from_view(view: ImageView<'_, u8>) -> CorrMatchResult<Self> {
+        let width = view.width();
+        let height = view.height();
+        let needed = width
+            .checked_mul(height)
+            .ok_or(CorrMatchError::InvalidDimensions { width, height })?;
+        let mut data = vec![0u8; needed];
+        for y in 0..height {
+            let row = view.row(y).ok_or_else(|| {
+                let needed = (y + 1)
+                    .checked_mul(view.stride())
+                    .and_then(|v| v.checked_add(view.width()))
+                    .unwrap_or(usize::MAX);
+                CorrMatchError::BufferTooSmall {
+                    needed,
+                    got: view.as_slice().len(),
+                }
+            })?;
+            let start = y * width;
+            let end = start + width;
+            data[start..end].copy_from_slice(row);
+        }
+        Self::from_vec(data, width, height)
+    }
+
+    /// Returns a borrowed view of the image.
+    pub fn view(&self) -> ImageView<'_, u8> {
+        ImageView {
+            data: &self.data,
+            width: self.width,
+            height: self.height,
+            stride: self.stride,
+        }
+    }
+}
+
+/// Owned image pyramid built from a base level.
+pub struct ImagePyramid {
+    levels: Vec<OwnedImage>,
+}
+
+impl ImagePyramid {
+    /// Builds a pyramid from a base grayscale view.
+    ///
+    /// `max_levels` is clamped to at least 1 so the base level is always present.
+    pub fn build_u8(base: ImageView<'_, u8>, max_levels: usize) -> CorrMatchResult<Self> {
+        let max_levels = max_levels.max(1);
+        let mut levels = Vec::new();
+        levels.push(OwnedImage::from_view(base)?);
+
+        while levels.len() < max_levels {
+            let prev = levels.last().expect("levels is not empty");
+            let src = prev.view();
+            if src.width() < 2 || src.height() < 2 {
+                break;
+            }
+
+            let dst_width = src.width() / 2;
+            let dst_height = src.height() / 2;
+            let dst_len =
+                dst_width
+                    .checked_mul(dst_height)
+                    .ok_or(CorrMatchError::InvalidDimensions {
+                        width: dst_width,
+                        height: dst_height,
+                    })?;
+            let mut dst = vec![0u8; dst_len];
+
+            for y in 0..dst_height {
+                let row0 = src.row(y * 2).ok_or_else(|| {
+                    let needed = (y * 2 + 1)
+                        .checked_mul(src.stride())
+                        .and_then(|v| v.checked_add(src.width()))
+                        .unwrap_or(usize::MAX);
+                    CorrMatchError::BufferTooSmall {
+                        needed,
+                        got: src.as_slice().len(),
+                    }
+                })?;
+                let row1 = src.row(y * 2 + 1).ok_or_else(|| {
+                    let needed = (y * 2 + 2)
+                        .checked_mul(src.stride())
+                        .and_then(|v| v.checked_add(src.width()))
+                        .unwrap_or(usize::MAX);
+                    CorrMatchError::BufferTooSmall {
+                        needed,
+                        got: src.as_slice().len(),
+                    }
+                })?;
+
+                for x in 0..dst_width {
+                    let a = row0[2 * x];
+                    let b = row0[2 * x + 1];
+                    let c = row1[2 * x];
+                    let d = row1[2 * x + 1];
+                    let sum = u16::from(a) + u16::from(b) + u16::from(c) + u16::from(d);
+                    dst[y * dst_width + x] = ((sum + 2) / 4) as u8;
+                }
+            }
+
+            levels.push(OwnedImage::from_vec(dst, dst_width, dst_height)?);
+        }
+
+        Ok(Self { levels })
+    }
+
+    /// Returns all pyramid levels (level 0 is the base resolution).
+    pub fn levels(&self) -> &[OwnedImage] {
+        &self.levels
+    }
+
+    /// Returns a view for a specific pyramid level.
+    pub fn level(&self, index: usize) -> Option<ImageView<'_, u8>> {
+        self.levels.get(index).map(|level| level.view())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,17 @@
 //!
 //! This crate currently provides scaffolding only; algorithms are not implemented yet.
 
+pub mod image;
+pub mod template;
+pub mod util;
+
 mod bank;
 mod candidate;
-mod image;
 mod kernel;
 mod refine;
 mod search;
-mod template;
-mod util;
 
-pub use util::error::{CorrMatchError, Result};
+pub use image::pyramid::ImagePyramid;
+pub use image::ImageView;
+pub use template::{Template, TemplatePlan};
+pub use util::{CorrMatchError, CorrMatchResult};

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -1,4 +1,28 @@
-//! Template metadata, planning, and rotation helpers.
+//! Template storage and planning utilities.
 
-pub(crate) mod plan;
+use crate::image::pyramid::OwnedImage;
+use crate::image::ImageView;
+use crate::util::CorrMatchResult;
+
+mod plan;
 pub(crate) mod rotate;
+
+pub use plan::TemplatePlan;
+
+/// Owned template image in contiguous grayscale format.
+pub struct Template {
+    img: OwnedImage,
+}
+
+impl Template {
+    /// Creates a template from a contiguous grayscale buffer.
+    pub fn new(data: Vec<u8>, width: usize, height: usize) -> CorrMatchResult<Self> {
+        let img = OwnedImage::from_vec(data, width, height)?;
+        Ok(Self { img })
+    }
+
+    /// Returns a borrowed view of the template data.
+    pub fn view(&self) -> ImageView<'_, u8> {
+        self.img.view()
+    }
+}

--- a/src/template/plan.rs
+++ b/src/template/plan.rs
@@ -1,1 +1,105 @@
-//! Planning structures for template matching stages.
+//! Template plan precomputation for ZNCC-like metrics.
+
+use crate::image::ImageView;
+use crate::util::{CorrMatchError, CorrMatchResult};
+
+/// Precomputed statistics and zero-mean buffer for template matching.
+pub struct TemplatePlan {
+    width: usize,
+    height: usize,
+    mean: f32,
+    inv_std: f32,
+    zero_mean: Vec<f32>,
+}
+
+impl TemplatePlan {
+    /// Builds a plan from a template view.
+    pub fn from_view(tpl: ImageView<'_, u8>) -> CorrMatchResult<Self> {
+        let width = tpl.width();
+        let height = tpl.height();
+        let count = width
+            .checked_mul(height)
+            .ok_or(CorrMatchError::InvalidDimensions { width, height })?;
+
+        let mut sum = 0.0f64;
+        let mut sum_sq = 0.0f64;
+        for y in 0..height {
+            let row = tpl.row(y).ok_or_else(|| {
+                let needed = (y + 1)
+                    .checked_mul(tpl.stride())
+                    .and_then(|v| v.checked_add(tpl.width()))
+                    .unwrap_or(usize::MAX);
+                CorrMatchError::BufferTooSmall {
+                    needed,
+                    got: tpl.as_slice().len(),
+                }
+            })?;
+            for &value in row {
+                let v = value as f64;
+                sum += v;
+                sum_sq += v * v;
+            }
+        }
+
+        let count_f = count as f64;
+        let mean_f64 = sum / count_f;
+        let variance = sum_sq / count_f - mean_f64 * mean_f64;
+        if variance <= 1e-8 {
+            return Err(CorrMatchError::DegenerateTemplate {
+                reason: "zero variance",
+            });
+        }
+
+        let mean = mean_f64 as f32;
+        let inv_std = (1.0 / variance.sqrt()) as f32;
+        let mut zero_mean = Vec::with_capacity(count);
+        for y in 0..height {
+            let row = tpl.row(y).ok_or_else(|| {
+                let needed = (y + 1)
+                    .checked_mul(tpl.stride())
+                    .and_then(|v| v.checked_add(tpl.width()))
+                    .unwrap_or(usize::MAX);
+                CorrMatchError::BufferTooSmall {
+                    needed,
+                    got: tpl.as_slice().len(),
+                }
+            })?;
+            for &value in row {
+                zero_mean.push(value as f32 - mean);
+            }
+        }
+
+        Ok(Self {
+            width,
+            height,
+            mean,
+            inv_std,
+            zero_mean,
+        })
+    }
+
+    /// Returns the template width in pixels.
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    /// Returns the template height in pixels.
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    /// Returns the mean intensity of the template.
+    pub fn mean(&self) -> f32 {
+        self.mean
+    }
+
+    /// Returns the inverse standard deviation of the template.
+    pub fn inv_std(&self) -> f32 {
+        self.inv_std
+    }
+
+    /// Returns the zero-mean template buffer in row-major order.
+    pub fn zero_mean(&self) -> &[f32] {
+        &self.zero_mean
+    }
+}

--- a/src/util/error.rs
+++ b/src/util/error.rs
@@ -3,15 +3,33 @@
 use thiserror::Error;
 
 /// Result alias for corrmatch operations.
-pub type Result<T> = std::result::Result<T, CorrMatchError>;
+pub type CorrMatchResult<T> = std::result::Result<T, CorrMatchError>;
 
-/// Errors that can occur when running corrmatch algorithms.
-#[derive(Debug, Error)]
+/// Errors that can occur when running corrmatch operations.
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum CorrMatchError {
-    /// The input data or parameters are invalid.
-    #[error("invalid input: {0}")]
-    InvalidInput(&'static str),
-    /// Placeholder for unfinished features.
-    #[error("not implemented: {0}")]
-    NotImplemented(&'static str),
+    /// The provided dimensions are invalid (must be non-zero).
+    #[error("invalid dimensions: width={width} height={height}")]
+    InvalidDimensions { width: usize, height: usize },
+    /// The provided stride is smaller than the image width.
+    #[error("invalid stride: width={width} stride={stride}")]
+    InvalidStride { width: usize, stride: usize },
+    /// The backing buffer is too small for the requested view.
+    #[error("buffer too small: needed={needed} got={got}")]
+    BufferTooSmall { needed: usize, got: usize },
+    /// The requested ROI lies outside the image bounds.
+    #[error(
+        "roi out of bounds: x={x} y={y} width={width} height={height} img_width={img_width} img_height={img_height}"
+    )]
+    RoiOutOfBounds {
+        x: usize,
+        y: usize,
+        width: usize,
+        height: usize,
+        img_width: usize,
+        img_height: usize,
+    },
+    /// The template is degenerate and cannot be normalized.
+    #[error("degenerate template: {reason}")]
+    DegenerateTemplate { reason: &'static str },
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,6 @@
 //! Shared utility helpers.
 
-pub(crate) mod error;
+pub mod error;
 pub(crate) mod math;
+
+pub use error::{CorrMatchError, CorrMatchResult};

--- a/tests/core_types.rs
+++ b/tests/core_types.rs
@@ -1,0 +1,125 @@
+use corrmatch::{CorrMatchError, ImagePyramid, ImageView, Template, TemplatePlan};
+
+#[test]
+fn image_view_rejects_invalid_dimensions() {
+    let data = [0u8; 4];
+
+    let err = ImageView::from_slice(&data, 0, 1).err().unwrap();
+    assert_eq!(
+        err,
+        CorrMatchError::InvalidDimensions {
+            width: 0,
+            height: 1,
+        }
+    );
+
+    let err = ImageView::from_slice(&data, 1, 0).err().unwrap();
+    assert_eq!(
+        err,
+        CorrMatchError::InvalidDimensions {
+            width: 1,
+            height: 0,
+        }
+    );
+}
+
+#[test]
+fn image_view_rejects_invalid_stride() {
+    let data = [0u8; 8];
+
+    let err = ImageView::new(&data, 4, 1, 3).err().unwrap();
+    assert_eq!(
+        err,
+        CorrMatchError::InvalidStride {
+            width: 4,
+            stride: 3,
+        }
+    );
+}
+
+#[test]
+fn image_view_rejects_small_buffer() {
+    let data = [0u8; 3];
+
+    let err = ImageView::new(&data, 2, 2, 2).err().unwrap();
+    assert_eq!(err, CorrMatchError::BufferTooSmall { needed: 4, got: 3 });
+}
+
+#[test]
+fn image_view_roi_matches_expected_values() {
+    let data: Vec<u8> = (0u8..16).collect();
+    let view = ImageView::from_slice(&data, 4, 4).unwrap();
+    assert_eq!(view.stride(), 4);
+    assert_eq!(view.as_slice(), data.as_slice());
+
+    let roi = view.roi(1, 1, 2, 2).unwrap();
+    assert_eq!(roi.width(), 2);
+    assert_eq!(roi.height(), 2);
+    assert_eq!(roi.stride(), 4);
+    assert_eq!(roi.row(0).unwrap(), &[5u8, 6u8]);
+    assert_eq!(roi.row(1).unwrap(), &[9u8, 10u8]);
+    assert_eq!(roi.get(0, 0).copied(), Some(5u8));
+    assert!(roi.get(2, 0).is_none());
+
+    let err = view.roi(3, 3, 2, 2).err().unwrap();
+    assert_eq!(
+        err,
+        CorrMatchError::RoiOutOfBounds {
+            x: 3,
+            y: 3,
+            width: 2,
+            height: 2,
+            img_width: 4,
+            img_height: 4,
+        }
+    );
+}
+
+#[test]
+fn image_pyramid_downsamples_by_two() {
+    let data: Vec<u8> = (0u8..16).collect();
+    let view = ImageView::from_slice(&data, 4, 4).unwrap();
+
+    let pyramid = ImagePyramid::build_u8(view, 10).unwrap();
+    assert_eq!(pyramid.levels().len(), 3);
+
+    let level1 = pyramid.level(1).unwrap();
+    assert_eq!(level1.width(), 2);
+    assert_eq!(level1.height(), 2);
+    assert_eq!(level1.row(0).unwrap(), &[3u8, 5u8]);
+    assert_eq!(level1.row(1).unwrap(), &[11u8, 13u8]);
+
+    let level2 = pyramid.level(2).unwrap();
+    assert_eq!(level2.width(), 1);
+    assert_eq!(level2.height(), 1);
+}
+
+#[test]
+fn template_plan_matches_known_stats() {
+    let tpl = Template::new(vec![0u8, 1, 2, 3], 2, 2).unwrap();
+    let plan = TemplatePlan::from_view(tpl.view()).unwrap();
+
+    let expected_mean = 1.5f32;
+    let expected_inv_std = 1.0f32 / 1.25f32.sqrt();
+    assert_eq!(plan.width(), 2);
+    assert_eq!(plan.height(), 2);
+    assert!((plan.mean() - expected_mean).abs() < 1e-6);
+    assert!((plan.inv_std() - expected_inv_std).abs() < 1e-6);
+
+    let expected_zero_mean = [-1.5f32, -0.5f32, 0.5f32, 1.5f32];
+    for (value, expected) in plan.zero_mean().iter().zip(expected_zero_mean.iter()) {
+        assert!((value - expected).abs() < 1e-6);
+    }
+}
+
+#[test]
+fn template_plan_rejects_degenerate_templates() {
+    let tpl = Template::new(vec![5u8; 4], 2, 2).unwrap();
+    let err = TemplatePlan::from_view(tpl.view()).err().unwrap();
+    assert_eq!(
+        err,
+        CorrMatchError::DegenerateTemplate {
+            reason: "zero variance",
+        }
+    );
+}


### PR DESCRIPTION
- Add core error types and result alias for fallible APIs.
- Add `ImageView`, `ImagePyramid`, `Template`, and `TemplatePlan` foundations.
- Add unit tests for image views, pyramid downsampling, and template stats.